### PR TITLE
fix(saucerswap-monitor): add default action to in-range notification

### DIFF
--- a/apps/saucerswap-monitor/ngsw-config.json
+++ b/apps/saucerswap-monitor/ngsw-config.json
@@ -42,7 +42,7 @@
       "cacheConfig": {
         "maxSize": 1,
         "maxAge": "1d",
-        "timeout": "2s",
+        "timeout": "0u",
         "strategy": "freshness"
       }
     },

--- a/libs/saucer-swap-monitor/src/lib/notifications.ts
+++ b/libs/saucer-swap-monitor/src/lib/notifications.ts
@@ -93,4 +93,16 @@ export class SSLPPInRangeNotification extends NGSWNotification<SSLPPInRangeNotif
       this.meta.walletCount > 1 ? 's' : ''
     }.`;
   }
+
+  protected override getData() {
+    return {
+      onActionClick: {
+        default: {
+          operation:
+            NGSWNotificationActionOperationType.NavigateLastFocusedOrOpen,
+          url: '/',
+        },
+      },
+    };
+  }
 }


### PR DESCRIPTION
- Add default action to in-range notification
- Cache Saucerswap APIs using stale-while-revalidate strategy for a better first load performance
